### PR TITLE
fix/slow-allocation

### DIFF
--- a/app/public/tailwind.css
+++ b/app/public/tailwind.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.1.17 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.1.18 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {

--- a/app/views/server/allocations.ejs
+++ b/app/views/server/allocations.ejs
@@ -67,25 +67,37 @@
 
     // Function to load server details
     function loadServerDetails() {
-        document.getElementById('allocations-loading').classList.remove('hidden');
-        document.getElementById('allocations-list').classList.add('hidden');
-        document.getElementById('allocations-empty').classList.add('hidden');
-
         fetch(`/api/server/${serverId}`)
             .then(response => response.json())
             .then(data => {
                 document.getElementById('server-name').textContent = data.attributes.name;
                 document.getElementById('server-name-breadcrumb').textContent = data.attributes.name;
                 document.getElementById('server-description').textContent = data.attributes.description || t.noDescription;
-                updateAllocationsList(data.attributes.relationships.allocations.data);
             })
             .catch(error => {
                 console.error('Error fetching server details:', error);
                 showError(t.loadDetailsError);
             })
-            .finally(() => {
-                document.getElementById('allocations-loading').classList.add('hidden');
-            });
+    }
+
+    // function to fetch allocations
+    function fetchAllocationList() {
+      document.getElementById('allocations-list').classList.add('hidden');
+      document.getElementById('allocations-empty').classList.add('hidden');
+      document.getElementById('allocations-loading').classList.remove('hidden');
+
+      fetch(`/api/server/${serverId}/allocations`)
+        .then(response => response.json())
+        .then(data => {
+          updateAllocationsList(data.data);
+        })
+        .catch(error => {
+          console.error('Error fetching allocation list:', error);
+          showError(t.loadDetailsError);
+        })
+        .finally(() => {
+          document.getElementById('allocations-loading').classList.add('hidden');
+        });
     }
 
     // Function to update the allocations list
@@ -183,7 +195,7 @@
             return response.json();
         })
         .then(data => {
-            loadServerDetails();
+            fetchAllocationList();
         })
         .catch(error => {
             showError(t.createLimit);
@@ -203,20 +215,21 @@
     function deleteAllocation(allocationId) {
         if (!allocationId) {
             showError('Missing allocation Id!')
+            return;
         }
         if (!confirm(t.confirmDelete + '?')) {
             return;
         }
 
         fetch(`/api/server/${serverId}/allocations/${allocationId}`, {
-            method: 'DELETE'
+            method: 'DELETE',
         })
         .then(response => {
             if (!response.ok) {
                 if (response.status === 404) throw new Error('The selected allocation does not exist');
                 throw new Error(response.status)
             }
-            loadServerDetails();
+            fetchAllocationList();
         })
         .catch(error => {
             showError(t.deleteFailed + '\n' + error);
@@ -224,7 +237,10 @@
     }
 
     // Load server details when the page loads
-    document.addEventListener('DOMContentLoaded', loadServerDetails);
+    document.addEventListener('DOMContentLoaded', () => {
+      loadServerDetails();
+      fetchAllocationList();
+    });
 </script>
 
 <%- include('../components/bottom') %>


### PR DESCRIPTION
This PR fixes the allocation's ui updates taking way longer than expected whereas pterodactyl is updated faster

**root cause**:
Using the server details fetch api to get the allocations instead of the recommended given way to fetch allocations most probably because it caches the server details but not the allocation list.